### PR TITLE
Migration guide for systemparams and insert()

### DIFF
--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -25,3 +25,45 @@ fn foo(mut commands: Commands) {
 Systems using the old `commands: &mut Commands` syntax in 0.5 will fail to compile when calling `foo.system()`.
 
 This change was made because `Commands` now holds an internal `World` reference to enable safe Entity allocations.
+
+Note: The internal `World` reference requires two lifetime parameters to pass Commands into a non-system function: ```commands: &'a mut Commands<'b>```
+
+## Systems allow a maximum of 12 top-level SystemParams, down from 15
+
+```rust
+// 0.4
+fn foo(r1: Res<Thing1>, r2: Res<Thing2>, r3: Res<Thing3>, r4: Res<Thing4>, ... r15: Res<Thing15>) {
+}
+
+// 0.5
+fn foo(r1_thru_3: (Res<Thing1>, Res<Thing2>, Res<Thing3>), r4: Res<Thing4>, ... r15: Res<Thing15>) {
+}
+```
+
+System functions with more than 12 arguments will no longer compile, as SystemParams rely on Rust's default impl for tuples.
+
+To work around this limitation (and improve function signature readability), systems can use nested tuples, as shown above, or leverage [derived parameters](https://github.com/bevyengine/bevy/blob/main/examples/ecs/system_param.rs).
+
+## Commands insert() API is now used for a single component
+
+```rust
+// 0.4
+// component
+commands.insert_one(entiy, MyComponent)
+commands.insert(entity, (MyComponent,))
+// bundle
+commands.insert(entity, Bundle)
+
+
+// 0.5
+// component
+commands.insert(entity, MyComponent)
+// bundle
+commands.insert_bundle(entity, MyBundle)
+```
+
+Instead of using `commands.insert_one()` for a lone component, it is now possible to simply call `commands.insert()`.
+
+This means that `commands.insert()` will no longer accept a bundle as an argument. For this, the new API is `commands.insert_bundle()`.
+
+This change helps to clarify the difference between components and bundles, and brings `Commands` into alignment with other Bevy APIs. It also eliminates the confusion associated with calling `commands.insert()` on a tuple for the single-component case.


### PR DESCRIPTION
Also added a note about lifetime parameters for Commands to section 1. Can remove if that's too confusing.