### PR TITLE
Add points 4&5 about Events API and add_resource => insert_resource

### DIFF
--- a/content/learn/book/migration-guides/0.4-0.5/_index.md
+++ b/content/learn/book/migration-guides/0.4-0.5/_index.md
@@ -67,3 +67,46 @@ Instead of using `commands.insert_one()` for a lone component, it is now possibl
 This means that `commands.insert()` will no longer accept a bundle as an argument. For this, the new API is `commands.insert_bundle()`.
 
 This change helps to clarify the difference between components and bundles, and brings `Commands` into alignment with other Bevy APIs. It also eliminates the confusion associated with calling `commands.insert()` on a tuple for the single-component case.
+
+## Simplified Events
+
+```rust
+// 0.4
+fn event_reader_system(
+    mut my_event_reader: Local<EventReader<MyEvent>>,
+    my_events: Res<Events<MyEvent>>,
+) {
+    for my_event in my_event_reader.iter(&my_events) {
+        // do things with your event
+    }
+}
+
+// 0.5
+fn event_reader_system(mut my_event_reader: EventReader<MyEvent>) {
+    for my_event in my_event_reader.iter() {
+        // do things with your event
+    }
+}
+```
+You no longer need two system parameters to read your events. One `EventReader` is sufficient.
+
+Following the above example of using an `EventReader` to read events, you can now use `EventWriter` to create new ones.
+```rust
+// 0.4
+fn event_writer_system(
+    mut my_events: ResMut<Events<MyEvent>>,
+) {
+    my_events.send(MyEvent);
+}
+
+// 0.5
+fn event_writer_system(
+    mut my_events: EventWriter<MyEvent>
+) {
+    my_events.send(MyEvent);
+}
+```
+
+## `AppBuilder::add_resource` is now called `AppBuilder::insert_resource`
+
+This is a small change to have function names on `AppBuilder` consistent with the `Commands` API.


### PR DESCRIPTION
Point 5 does currently not include the renaming of `add_thread_local_resource` to `insert_thread_local_resource`, because the same function is renamed again in point  14 to `insert_non_send_resource`. I think it would be confusing here to list the first rename or already include the rename to `insert_non_send_resource`.